### PR TITLE
Fixed the wildcard exclusions for folders

### DIFF
--- a/bin/v-backup-user
+++ b/bin/v-backup-user
@@ -54,15 +54,15 @@ get_user_disk_usage() {
 			| awk -F "DOMAIN='" '{print $2}' | cut -f 1 -d \')
 
 		for domain in $domains; do
-			exclusion=$(echo -e "$web_exclusions" | tr ',' '\n' | grep "^$domain$")
+			exclusion=$(echo -e "$web_exclusions" | tr ',' '\n' | grep "^$domain\|\*$")
 			if [ -z "$exclusion" ]; then
 				# Defining home directory
 				home_dir="$HOMEDIR/$user/web/$domain/"
-				exlusion=$(echo -e "$web_exclusions" | tr ',' '\n' | grep "^$domain:")
+				exclusion=$(echo -e "$web_exclusions" | tr ',' '\n' | grep "^$domain\|\*:")
 				fargs=()
 
-				if [ -n "$exlusion" ]; then
-					xdirs=$(echo -e "$exlusion" | tr ':' '\n' | grep -v "$domain")
+				if [ -n "$exclusion" ]; then
+					xdirs=$(echo -e "$exclusion" | tr ':' '\n' | grep -v "$domain\|\*")
 					for xpath in $xdirs; do
 						fargs+=(--exclude="$xpath")
 					done
@@ -83,7 +83,7 @@ get_user_disk_usage() {
 			| awk -F "DOMAIN='" '{print $2}' | cut -f 1 -d \')
 
 		for domain in $domains; do
-			check_exl=$(echo "$mail_exclusions" | tr ',' '\n' | grep "^$domain$")
+			check_exl=$(echo "$mail_exclusions" | tr ',' '\n' | grep "^$domain\|\*$")
 			if [ -f "$USER_DATA/mail/$domain.conf" ] && [ -z "$check_exl" ]; then
 				accounts=$(grep 'ACCOUNT=' "$USER_DATA/mail/$domain.conf" \
 					| awk -F "ACCOUNT='" '{print $2}' | cut -f 1 -d \')
@@ -245,7 +245,7 @@ if [ -n "$WEB_SYSTEM" ] && [ "$WEB" != '*' ]; then
 	# Parsing domain exclusions
 	conf="$USER_DATA/web.conf"
 	for domain in $(search_objects 'web' 'SUSPENDED' "*" 'DOMAIN'); do
-		exclusion=$(echo -e "$WEB" | tr ',' '\n' | grep "^$domain$")
+		exclusion=$(echo -e "$WEB" | tr ',' '\n' | grep "^$domain\|\*$")
 		if [ -z "$exclusion" ]; then
 			web_list="$web_list $domain"
 		else
@@ -361,12 +361,17 @@ if [ -n "$WEB_SYSTEM" ] && [ "$WEB" != '*' ]; then
 		cd $HOMEDIR/$user/web/$domain
 
 		# Define exclude arguments
-		exlusion=$(echo -e "$WEB" | tr ',' '\n' | grep "^$domain:")
+		exclusion=$(echo -e "$WEB" | tr ',' '\n' | grep "^$domain\|\*:")
 		set -f
 		fargs=()
 		fargs+=(--exclude='./logs/*')
-		if [ -n "$exlusion" ]; then
-			xdirs="$(echo -e "$exlusion" | tr ':' '\n' | grep -v $domain)"
+		if [ -n "$exclusion" ]; then
+
+			if [[ "$exclusion" =~ '*' ]]; then
+				exclusion="${exclusion/\*/$domain}"
+			fi
+
+			xdirs="$(echo -e "$exclusion" | tr ':' '\n' | grep -v $domain)"
 			for xpath in $xdirs; do
 				if [ -d "$xpath" ]; then
 					fargs+=(--exclude=$xpath/*)
@@ -404,7 +409,7 @@ if [ -n "$DNS_SYSTEM" ] && [ "$DNS" != '*' ]; then
 
 	# Parsing domain exclusions
 	for domain in $(search_objects 'dns' 'SUSPENDED' "*" 'DOMAIN'); do
-		exclusion=$(echo "$DNS" | tr ',' '\n' | grep "^$domain$")
+		exclusion=$(echo "$DNS" | tr ',' '\n' | grep "^$domain\|\*$")
 		if [ -z "$exclusion" ]; then
 			dns_list="$dns_list $domain"
 		else
@@ -458,7 +463,7 @@ if [ -n "$MAIL_SYSTEM" ] && [ "$MAIL" != '*' ]; then
 	# Parsing domain exclusions
 	conf="$USER_DATA/mail.conf"
 	for domain in $(search_objects 'mail' 'SUSPENDED' "*" 'DOMAIN'); do
-		check_exl=$(echo "$MAIL" | tr ',' '\n' | grep "^$domain$")
+		check_exl=$(echo "$MAIL" | tr ',' '\n' | grep "^$domain\|\*$")
 		if [ -z "$check_exl" ]; then
 			mail_list="$mail_list $domain"
 		else
@@ -498,7 +503,7 @@ if [ -n "$MAIL_SYSTEM" ] && [ "$MAIL" != '*' ]; then
 			exclusion=$(echo "$MAIL" | tr ',' '\n' | grep "$domain:")
 			exclusion=$(echo "$exclusion" | tr ':' '\n' | grep -E "^$account|\*")
 
-			# Checking exlusions
+			# Checking exclusions
 			if [ -z "$exclusion" ] && [[ "$MAIL_SYSTEM" =~ exim ]]; then
 				accounts+=($account)
 			else
@@ -634,7 +639,7 @@ if [ "$USER" != '*' ]; then
 	mkdir $tmpdir/user_dir
 	cd $HOMEDIR/$user
 
-	# Parsing directory exlusions
+	# Parsing directory exclusions
 	USER=''
 	if [ -e "$USER_DATA/backup-excludes.conf" ]; then
 		source $USER_DATA/backup-excludes.conf


### PR DESCRIPTION
Fixed the *:public_html format for web folders exclusions in backups (and DB's), as well as the typo of the "exclusions" variable (was `excusions`). It probably needs some more testing on DB/DNS/email exclusions, as I don't use any of that - but I have applied the same logic so hopefully it'll work fine!